### PR TITLE
Bug 1044253 - Assume no ftp STAT support

### DIFF
--- a/lib/ftp_filter.js
+++ b/lib/ftp_filter.js
@@ -9,9 +9,8 @@ var TIMEOUT = 60 * 60 * 1000; // 1 min
 Internal wrapper around jsftp
 */
 function ftpClient() {
-  var ftp = new FTP({
-    host: urls.FTP_HOST
-  });
+  var ftp = new FTP({ host: urls.FTP_HOST });
+  ftp.useList = true;
   ftp.socket.setTimeout(TIMEOUT);
   ftp.socket.once('timeout', function(data) {
     ftp.socket.destroy(); // should call the "ls" callback "err"


### PR DESCRIPTION
ftp `STAT` on ftp.mozilla.org causes issues that using `LIST` fixes (at least for @millermedeiros and me in the sf office)
