### PR TITLE
Filter prerelease builds by product name as well.

### DIFF
--- a/lib/prerelease_filter.js
+++ b/lib/prerelease_filter.js
@@ -31,6 +31,17 @@ function filterByOS(os, item) {
   );
 }
 
+/**
+Require the binary name to begin with the product name.  This is to deal with
+situations where a directory may contain both "b2g" and "firefox" builds.
+
+@param {String} product The product name plus any delimiter you also, ex: "b2g-"
+@param {Object} item from ftp.ls.
+*/
+function filterByProduct(product, item) {
+  return (item.name.indexOf(product) === 0);
+}
+
 function sortByTime(a, b) {
   var dateA = new Date(a.time);
   var dateB = new Date(b.time);
@@ -53,6 +64,7 @@ Filters a list of ftp.ls results by operating system.
 function filterItems(options, list) {
   var choices = list.
     filter(filterByOS.bind(null, options.os)).
+    filter(filterByProduct.bind(null, options.product)).
     sort(sortByTime);
 
   if (!choices.length)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozilla-get-url",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Utility to get the url of a particular version/release of a mozilla product (like firefox/b2g)",
   "main": "lib/locate.js",
   "scripts": {

--- a/test/fixtures/multi_version_b2g.json
+++ b/test/fixtures/multi_version_b2g.json
@@ -1311,6 +1311,29 @@
     }
   },
   {
+    "name": "firefox-27.0a1.multi.linux-x86_64.tar.bz2",
+    "type": 0,
+    "time": 1380053470000,
+    "size": "102809276",
+    "owner": "ftp",
+    "group": "ftp",
+    "userPermissions": {
+      "read": true,
+      "write": true,
+      "exec": false
+    },
+    "groupPermissions": {
+      "read": true,
+      "write": false,
+      "exec": false
+    },
+    "otherPermissions": {
+      "read": true,
+      "write": false,
+      "exec": false
+    }
+  },
+  {
     "name": "b2g-27.0a1.multi.linux-x86_64.tar.bz2",
     "type": 0,
     "time": 1380053460000,

--- a/test/prerelease_filter_test.js
+++ b/test/prerelease_filter_test.js
@@ -8,6 +8,10 @@ suite('filter', function() {
   suite('multi version', function() {
     var input = fixture('multi_version_b2g');
 
+    // For this case the fixture also includes a firefox binary that is more
+    // recent than the b2g binary.  There was a bug where we would pick the
+    // firefox binary over the b2g binary, so this provides our coverage to
+    // ensure that we filter by product name as well.
     test('os: linux-x86_64', function() {
       // in pre-release we have multiple mac types
       var result = subject({ product: 'b2g', os: 'linux-x86_64' }, input);


### PR DESCRIPTION
Sometimes "--product b2g" would return a firefox build that lived in the same
directory if its timestamp was as-recent/more-recent than the b2g builds that
live in the directory.

See https://github.com/mozilla-b2g/mozilla-download/issues/8 for more context.
